### PR TITLE
Change default dtype to str; use np.unicode_ rather than python str

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, James White'
 author = 'James White'
 
 # The short X.Y version
-version = ''
+version = '1.1.1'
 # The full version, including alpha/beta/rc tags
-release = ''
+release = '1.1.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/monitorframe/datamodel.py
+++ b/monitorframe/datamodel.py
@@ -102,7 +102,7 @@ class BaseDataModel(DataInterface, metaclass=PandasMeta):
                 ingestible = self.new_data.copy()
 
                 for key in self._array_types:
-                    ingestible[key] = ingestible[key].astype(np.unicode_)
+                    ingestible[key] = ingestible[key].apply(lambda x: repr(list(x)))
 
                 return ingestible
 
@@ -162,9 +162,6 @@ class BaseDataModel(DataInterface, metaclass=PandasMeta):
 
             # Convert array columns to numpy arrays. Leave as string if not specified
             for key, dtype in zip(array_cols, array_dtypes):
-                df[key] = df[key].apply(
-                    lambda x: np.array(x.strip('[]').replace("'", '').split(', '), dtype=dtype) if ',' in x
-                    else np.array(x.strip('[]').replace("'", '').split(), dtype=dtype)
-                )
+                df[key] = df[key].apply(lambda x: np.array(eval(x), dtype=dtype))
 
         return df

--- a/monitorframe/datamodel.py
+++ b/monitorframe/datamodel.py
@@ -102,7 +102,7 @@ class BaseDataModel(DataInterface, metaclass=PandasMeta):
                 ingestible = self.new_data.copy()
 
                 for key in self._array_types:
-                    ingestible[key] = ingestible[key].astype(str)
+                    ingestible[key] = ingestible[key].astype(np.unicode_)
 
                 return ingestible
 
@@ -158,9 +158,9 @@ class BaseDataModel(DataInterface, metaclass=PandasMeta):
 
         if array_cols:
             if not array_dtypes:
-                array_dtypes = repeat(float, len(array_cols))
+                array_dtypes = repeat(None, len(array_cols))
 
-            # Convert array columns to numpy arrays. Assume the dtype should be a float if not specified
+            # Convert array columns to numpy arrays. Leave as string if not specified
             for key, dtype in zip(array_cols, array_dtypes):
                 df[key] = df[key].apply(
                     lambda x: np.array(x.strip('[]').replace("'", '').split(', '), dtype=dtype) if ',' in x

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup_parameters = dict(
 
 setup(
     name='monitorframe',  # Required
-    version='1.1.0',  # Required
+    version='1.1.1',  # Required
     description='Framework for building instrument monitors.',  # Required
     author='James White; Space Telescope Science Institute',
     author_email='jwhite@stsci.edu',

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -119,9 +119,9 @@ class TestDataModel:
         query = datamodel_test_instance.model.select()
 
         if datamodel_test_instance._array_types:
-            # Check that the converted columns are floats by default
+            # Check that the converted columns are left as strings by default
             df = datamodel_test_instance.query_to_pandas(query, ['c'])
-            assert (type(df.c[0]) == list or type(df.c[0]) == np.ndarray) and type(df.c[0][0]) == np.float64
+            assert (type(df.c[0]) == list or type(df.c[0]) == np.ndarray) and type(df.c[0][0]) == np.unicode_
 
             # Check that the columns are converted into the specified dtype successfully
             df = datamodel_test_instance.query_to_pandas(query, ['c'], [int])

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -24,8 +24,26 @@ NEW_DATA_WITH_NPARRAY = {
     'c': [np.array([7, 8, 9]), np.array([10, 11, 12]), np.array([13, 14, 15])]
 }
 
+NEW_DATA_WITH_floats = {
+    'a': [1, 2, 3],
+    'b': [4, 5, 6],
+    'c': [[1.123, 2.234, -3.345], [1.123, 2.234, -3.345], [1.123, 2.234, -3.345]]
+}
 
-@pytest.fixture(params=[NEW_DATA, NEW_DATA_WITH_LIST, NEW_DATA_WITH_NPARRAY])
+NEW_DATA_WITH_bytestr = {
+    'a': [1, 2, 3],
+    'b': [4, 5, 6],
+    'c': [[b'a', b'b', b'c'], [b'd', b'e', b'f'], [b'g', b'h', b'i']]
+}
+
+NEW_DATA_NO_ARRAYS = {
+    'a': [1, 2, 3],
+    'b': [4, 5, 6],
+    'c': [7, 8, 9]
+}
+
+
+@pytest.fixture(params=[NEW_DATA, NEW_DATA_WITH_LIST, NEW_DATA_WITH_NPARRAY, NEW_DATA_WITH_floats, NEW_DATA_WITH_bytestr, NEW_DATA_NO_ARRAYS])
 def datamodel_test_instance(request):
     """Test fixture that creates a datamodel object (from BaseDataModel) using the different data configurations in
     NEW_DATA, NEW_DATA_WITH_LIST, and NEW_DATA_WITH_NPARRAY. This fixture also includes a clean-up if a database table
@@ -119,13 +137,12 @@ class TestDataModel:
         query = datamodel_test_instance.model.select()
 
         if datamodel_test_instance._array_types:
-            # Check that the converted columns are left as strings by default
-            df = datamodel_test_instance.query_to_pandas(query, ['c'])
-            assert (type(df.c[0]) == list or type(df.c[0]) == np.ndarray) and type(df.c[0][0]) == np.unicode_
+            # Check that the query can be converted
+            datamodel_test_instance.query_to_pandas(query, ['c'])
 
             # Check that the columns are converted into the specified dtype successfully
-            df = datamodel_test_instance.query_to_pandas(query, ['c'], [int])
-            assert (type(df.c[0]) == list or type(df.c[0]) == np.ndarray) and type(df.c[0][0]) == np.int64
+            df = datamodel_test_instance.query_to_pandas(query, ['c'], [str])
+            assert (type(df.c[0]) == list or type(df.c[0]) == np.ndarray) and type(df.c[0][0]) == np.unicode_
 
         else:
             # Check that the query is converted without array elements


### PR DESCRIPTION
This PR changes how array elements are stored in the database and how they're retrieved. 

Array elements are now converted to lists and stored as a string. Those strings are recovered from the database and evaluated to recover the list and elements as they were input. 

Resolves #13 
Resolves #11 