### PR TITLE
Refactor array storage and retrieval

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,9 +24,9 @@ copyright = '2019, James White'
 author = 'James White'
 
 # The short X.Y version
-version = '1.1.1'
+version = '1.2.0'
 # The full version, including alpha/beta/rc tags
-release = '1.1.1'
+release = '1.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/monitorframe/datamodel.py
+++ b/monitorframe/datamodel.py
@@ -167,5 +167,6 @@ class BaseDataModel(DataInterface, metaclass=PandasMeta):
         if array_cols:
             for key in array_cols:
                 df[key] = df.apply(lambda x: np.array(ast.literal_eval(x[key]), dtype=x[f'{key}_dtype']), axis=1)
+                df.drop(f'{key}_dtype', axis=1, inplace=True)
 
         return df

--- a/monitorframe/datamodel.py
+++ b/monitorframe/datamodel.py
@@ -142,7 +142,8 @@ class BaseDataModel(DataInterface, metaclass=PandasMeta):
         # Insert the dataframe into the database
         with self._database as db:
             if self._formatted_data is not None:
-                self._formatted_data.to_sql(self.table_name, db, if_exists='append', index=False)
+                dtypes = {key: 'BLOB' for key in self._array_types}
+                self._formatted_data.to_sql(self.table_name, db, if_exists='append', index=False, dtype=dtypes)
 
         # If the model wasn't created due to the table not existing, create the model.
         if self.model is None:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup_parameters = dict(
 
 setup(
     name='monitorframe',  # Required
-    version='1.1.1',  # Required
+    version='1.2.0',  # Required
     description='Framework for building instrument monitors.',  # Required
     author='James White; Space Telescope Science Institute',
     author_email='jwhite@stsci.edu',

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -12,38 +12,19 @@ NEW_DATA = {
     'c': [7, 8, 9]
 }
 
-NEW_DATA_WITH_LIST = {
+NEW_DATA_WITH_ARRAYS = {
     'a': [1, 2, 3],
     'b': [4, 5, 6],
-    'c': [[7, 8, 9], [10, 11, 12], [13, 14, 15]]
+    'list_arr': [[7, 8, 9], [10, 11, 12], [13, 14, 15]],
+    'np_arr': [np.array([7, 8, 9]), np.array([10, 11, 12]), np.array([13, 14, 15])],
+    'floats': [[1.123, 2.234, -3.345], [1.123, 2.234, -3.345], [1.123, 2.234, -3.345]],
+    'bytestr': [[b'a', b'b', b'c'], [b'd', b'e', b'f'], [b'g', b'h', b'i']]
 }
 
-NEW_DATA_WITH_NPARRAY = {
-    'a': [1, 2, 3],
-    'b': [4, 5, 6],
-    'c': [np.array([7, 8, 9]), np.array([10, 11, 12]), np.array([13, 14, 15])]
-}
-
-NEW_DATA_WITH_floats = {
-    'a': [1, 2, 3],
-    'b': [4, 5, 6],
-    'c': [[1.123, 2.234, -3.345], [1.123, 2.234, -3.345], [1.123, 2.234, -3.345]]
-}
-
-NEW_DATA_WITH_bytestr = {
-    'a': [1, 2, 3],
-    'b': [4, 5, 6],
-    'c': [[b'a', b'b', b'c'], [b'd', b'e', b'f'], [b'g', b'h', b'i']]
-}
-
-NEW_DATA_NO_ARRAYS = {
-    'a': [1, 2, 3],
-    'b': [4, 5, 6],
-    'c': [7, 8, 9]
-}
+TEST_ARRAY_KEYS = ['list_arr', 'np_arr', 'floats', 'bytestr']
 
 
-@pytest.fixture(params=[NEW_DATA, NEW_DATA_WITH_LIST, NEW_DATA_WITH_NPARRAY, NEW_DATA_WITH_floats, NEW_DATA_WITH_bytestr, NEW_DATA_NO_ARRAYS])
+@pytest.fixture(params=[NEW_DATA, NEW_DATA_WITH_ARRAYS])
 def datamodel_test_instance(request):
     """Test fixture that creates a datamodel object (from BaseDataModel) using the different data configurations in
     NEW_DATA, NEW_DATA_WITH_LIST, and NEW_DATA_WITH_NPARRAY. This fixture also includes a clean-up if a database table
@@ -76,23 +57,20 @@ class TestDataModel:
 
     def test_find_array_types(self, datamodel_test_instance):
         """Test that the array column is found successfully."""
-        test_array_keys = ['c']
-
         if datamodel_test_instance._array_types:
-            assert datamodel_test_instance._array_types == test_array_keys
+            assert datamodel_test_instance._array_types == TEST_ARRAY_KEYS
 
         else:
             assert not datamodel_test_instance._array_types
 
     def test_ingest_format(self, datamodel_test_instance):
         """Test that for array columns, the elements are converted into strings."""
-        test_array_keys = ['c']
 
         if datamodel_test_instance._array_types:
-            for key in test_array_keys:
+            for key in TEST_ARRAY_KEYS:
                 assert (
-                               datamodel_test_instance._formatted_data[key].dtypes == 'O' and
-                               type(datamodel_test_instance._formatted_data[key][0]) == str
+                        datamodel_test_instance._formatted_data[key].dtypes == 'O' and
+                        type(datamodel_test_instance._formatted_data[key][0]) == str
                 )
 
         else:
@@ -110,10 +88,28 @@ class TestDataModel:
 
         # Check that a peewee model can be constructed and queried
         query = list(datamodel_test_instance.model.select().dicts())
+
         assert len(query) == 3
 
         # Check that the model columns are correct
-        assert sorted(datamodel_test_instance.model._meta.columns.keys()) == ['a', 'b', 'c']
+        if datamodel_test_instance._array_types:
+            expected = [
+                'a',
+                'b',
+                'bytestr',
+                'bytestr_dtype',
+                'floats',
+                'floats_dtype',
+                'list_arr',
+                'list_arr_dtype',
+                'np_arr',
+                'np_arr_dtype'
+            ]
+
+            assert sorted(datamodel_test_instance.model._meta.columns.keys()) == expected
+
+        else:
+            assert sorted(datamodel_test_instance.model._meta.columns.keys()) == ['a', 'b', 'c']
 
     def test_ingest_fails(self, datamodel_test_instance):
         """Test that the table does not accept duplicates when a primary key is defined."""
@@ -138,12 +134,16 @@ class TestDataModel:
 
         if datamodel_test_instance._array_types:
             # Check that the query can be converted
-            datamodel_test_instance.query_to_pandas(query, ['c'])
+            df = datamodel_test_instance.query_to_pandas(query, TEST_ARRAY_KEYS)
 
             # Check that the columns are converted into the specified dtype successfully
-            df = datamodel_test_instance.query_to_pandas(query, ['c'], [str])
-            assert (type(df.c[0]) == list or type(df.c[0]) == np.ndarray) and type(df.c[0][0]) == np.unicode_
+            for key in TEST_ARRAY_KEYS:
+                value = NEW_DATA_WITH_ARRAYS[key]
+
+                assert (type(df.loc[0, key]) == np.ndarray) and df.loc[0, key].dtype == df.loc[0, f'{key}_dtype']
+                assert np.array_equal(df.loc[0, key], np.array(value[0]))
 
         else:
             # Check that the query is converted without array elements
-            datamodel_test_instance.query_to_pandas(query)
+            query_df = datamodel_test_instance.query_to_pandas(query)
+            assert query_df.equals(datamodel_test_instance.new_data)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -131,6 +131,7 @@ class TestDataModel:
         """Test the query to pandas method."""
         datamodel_test_instance.ingest()
         query = datamodel_test_instance.model.select()
+        comparison = datamodel_test_instance._formatted_data
 
         if datamodel_test_instance._array_types:
             # Check that the query can be converted
@@ -140,7 +141,11 @@ class TestDataModel:
             for key in TEST_ARRAY_KEYS:
                 value = NEW_DATA_WITH_ARRAYS[key]
 
-                assert (type(df.loc[0, key]) == np.ndarray) and df.loc[0, key].dtype == df.loc[0, f'{key}_dtype']
+                assert (
+                        type(df.loc[0, key]) == np.ndarray and
+                        df.loc[0, key].dtype == comparison.loc[0, f'{key}_dtype']
+                )
+
                 assert np.array_equal(df.loc[0, key], np.array(value[0]))
 
         else:


### PR DESCRIPTION
This PR refactors how array elements are stored in database columns. 

Arrays are now converted to python `list`s before being cast as a `str` object. In addition, the datatype of those lists are stored in the `_formatted_data` data frame as columns so that upon retrieval from the database, the array elements can be converted into arrays of appropriate type. 